### PR TITLE
Add customizable endpoint exclusion

### DIFF
--- a/camel-plantuml-jar/pom.xml
+++ b/camel-plantuml-jar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>camel-plantuml</artifactId>
         <groupId>io.github.ncasaux</groupId>
-        <version>1.7.0</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/ConsumersDiagramGenerator.java
+++ b/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/ConsumersDiagramGenerator.java
@@ -60,6 +60,11 @@ public class ConsumersDiagramGenerator {
                 }
             }
 
+            if (parameters.uriFilterPattern().matcher(endpointBaseUri).matches()) {
+                drawConsumer = false;
+                LOGGER.info("{} matches the uriFilterPattern \"{}\", consumer will not be part of the diagram", consumerInfo, parameters.uriFilterPattern());
+            }
+
             if (parameters.connectRoutes() && producersInfo.stream().anyMatch(producerInfo -> producerInfo.getEndpointUri().equals(endpointBaseUri)) && Arrays.asList(GetRoutesInfoProcessor.camelInternalEndpointSchemeFilters).contains(new URI(endpointBaseUri).getScheme())) {
                 drawConsumer = false;
                 LOGGER.info("Parameter \"connectRoutes\" is \"true\", consumer in routeId \"{}\" from internal endpointBaseUri \"{}\" will not be part of the diagram", routeId, endpointBaseUri);

--- a/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/EndpointsDiagramGenerator.java
+++ b/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/EndpointsDiagramGenerator.java
@@ -44,6 +44,11 @@ public class EndpointsDiagramGenerator {
                 }
             }
 
+            if (parameters.uriFilterPattern().matcher(endpointBaseUri).matches()) {
+                drawEndpoint = false;
+                LOGGER.info("EndpointBaseUri \"{}\" matches the uriFilterPattern \"{}\", endpoint will not be part of the diagram", endpointBaseUri, parameters.uriFilterPattern());
+            }
+
             if (parameters.connectRoutes() && endpointHasConsumer && endpointHasProducer && Arrays.asList(GetRoutesInfoProcessor.camelInternalEndpointSchemeFilters).contains(new URI(endpointBaseUri).getScheme())) {
                 drawEndpoint = false;
                 LOGGER.info("Parameter \"connectRoutes\" is \"true\", endpointBaseUri \"{}\" is internal and has both consumer and producer, endpoint will not be part of the diagram", endpointBaseUri);

--- a/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/ProducersDiagramGenerator.java
+++ b/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/ProducersDiagramGenerator.java
@@ -58,6 +58,11 @@ public class ProducersDiagramGenerator {
                 }
             }
 
+            if (parameters.uriFilterPattern().matcher(routeEndpointBaseUri).matches() || parameters.uriFilterPattern().matcher(endpointBaseUri).matches()) {
+                drawProducer = false;
+                LOGGER.info("{} matches the uriFilterPattern \"{}\", producer will not be part of the diagram", producerInfo, parameters.uriFilterPattern());
+            }
+
             if (drawProducer) {
                 if (!producerInfo.getUseDynamicEndpoint()) {
                     String targetElementId = endpointBaseUrisInfo.get(endpointBaseUri).getDiagramElementId();

--- a/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/RoutesDiagramGenerator.java
+++ b/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/RoutesDiagramGenerator.java
@@ -50,7 +50,8 @@ public class RoutesDiagramGenerator {
 
             if (parameters.uriFilterPattern().matcher(routeEndpointBaseUri).matches()) {
                 drawRoute = false;
-                LOGGER.info("Route with id \"{}\" matches the uriFilterPattern \"{}\", route will not be part of the diagram", routeId, parameters.uriFilterPattern());
+                LOGGER.info("Route with id \"{}\" and routeEndpointBaseUri \"{}\" matches the uriFilterPattern \"{}\", " +
+                        "route will not be part of the diagram", routeId, routeEndpointBaseUri, parameters.uriFilterPattern());
             }
 
             if (drawRoute) {

--- a/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/RoutesDiagramGenerator.java
+++ b/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/generator/RoutesDiagramGenerator.java
@@ -1,6 +1,7 @@
 package io.github.ncasaux.camelplantuml.generator;
 
 import io.github.ncasaux.camelplantuml.model.RouteInfo;
+import io.github.ncasaux.camelplantuml.model.query.Parameters;
 import io.github.ncasaux.camelplantuml.processor.GetRoutesInfoProcessor;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -17,7 +18,7 @@ public class RoutesDiagramGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RoutesDiagramGenerator.class);
 
-    public static String generateUmlString(HashMap<String, RouteInfo> routesInfo) throws IOException {
+    public static String generateUmlString(HashMap<String, RouteInfo> routesInfo, Parameters parameters) throws IOException {
 
         String umlRouteTemplate = IOUtils.toString(Objects.requireNonNull(RoutesDiagramGenerator.class.getClassLoader().getResourceAsStream("plantuml/routeTemplate")), StandardCharsets.UTF_8);
         String umlRouteTemplateNoDescription = IOUtils.toString(Objects.requireNonNull(RoutesDiagramGenerator.class.getClassLoader().getResourceAsStream("plantuml/routeTemplateNoDescription")), StandardCharsets.UTF_8);
@@ -45,6 +46,11 @@ public class RoutesDiagramGenerator {
                     LOGGER.info("Route with id \"{}\" matches the endpoint filter \"{}\", route will not be part of the diagram", routeId, endpointBaseUriFilter);
                     break;
                 }
+            }
+
+            if (parameters.uriFilterPattern().matcher(routeEndpointBaseUri).matches()) {
+                drawRoute = false;
+                LOGGER.info("Route with id \"{}\" matches the uriFilterPattern \"{}\", route will not be part of the diagram", routeId, parameters.uriFilterPattern());
             }
 
             if (drawRoute) {

--- a/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/model/query/Parameters.java
+++ b/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/model/query/Parameters.java
@@ -1,14 +1,44 @@
 package io.github.ncasaux.camelplantuml.model.query;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
 public class Parameters {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Parameters.class);
+    private static final String MATCH_NOTHING_PATTERN_STRING = "(?!.*)";
 
     private final boolean connectRoutes;
 
-    public Parameters(boolean connectRoutes) {
+    private final Pattern uriFilterPattern;
+
+    public Parameters(boolean connectRoutes,
+                      String uriFilterPatternString) {
         this.connectRoutes = connectRoutes;
+
+        Pattern validUriFilterPattern;
+        try {
+            validUriFilterPattern = Pattern.compile(URLDecoder.decode(Objects.requireNonNullElse(uriFilterPatternString, MATCH_NOTHING_PATTERN_STRING),
+                    StandardCharsets.UTF_8));
+            LOGGER.info("Value for uriFilterPattern \"{}\"", uriFilterPatternString);
+        } catch (PatternSyntaxException e) {
+            LOGGER.info("Invalid value for uriFilterPattern \"{}\"; will be deactivated", uriFilterPatternString);
+            validUriFilterPattern = Pattern.compile(MATCH_NOTHING_PATTERN_STRING);
+        }
+
+        this.uriFilterPattern = validUriFilterPattern;
     }
 
     public boolean connectRoutes() {
         return connectRoutes;
+    }
+
+    public Pattern uriFilterPattern() {
+        return uriFilterPattern;
     }
 }

--- a/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/processor/GetRoutesInfoProcessor.java
+++ b/camel-plantuml-jar/src/main/java/io/github/ncasaux/camelplantuml/processor/GetRoutesInfoProcessor.java
@@ -31,7 +31,9 @@ public class GetRoutesInfoProcessor implements Processor {
     @Override
     public void process(Exchange exchange) throws Exception {
 
-        Parameters parameters = new Parameters(Boolean.parseBoolean(exchange.getIn().getHeader("connectRoutes", String.class)));
+        Parameters parameters = new Parameters(
+                Boolean.parseBoolean(exchange.getIn().getHeader("connectRoutes", String.class)),
+                exchange.getIn().getHeader("uriFilterPattern", String.class));
 
         HashMap<String, RouteInfo> routesInfo = new HashMap<>(); //Hashmap key will be the routeId of the Camel route
         ArrayList<ConsumerInfo> consumersInfo = new ArrayList<>();
@@ -72,7 +74,7 @@ public class GetRoutesInfoProcessor implements Processor {
 
         LOGGER.info("Generating PlantUML diagram");
         String umlString = HeaderDiagramGenerator.generateUmlString(exchange.getContext().getName())
-                .concat(RoutesDiagramGenerator.generateUmlString(routesInfo))
+                .concat(RoutesDiagramGenerator.generateUmlString(routesInfo, parameters))
                 .concat(EndpointsDiagramGenerator.generateUmlString(consumersInfo, producersInfo, endpointBaseUrisInfo, parameters))
                 .concat(ConsumersDiagramGenerator.generateUmlString(consumersInfo, producersInfo, endpointBaseUrisInfo, routesInfo, parameters))
                 .concat(ProducersDiagramGenerator.generateUmlString(consumersInfo, producersInfo, endpointBaseUrisInfo, routesInfo, parameters))

--- a/camel-plantuml-jar/src/test/java/DefaultExample/DefaultExampleWithInvalidUriFilterPatternTest.java
+++ b/camel-plantuml-jar/src/test/java/DefaultExample/DefaultExampleWithInvalidUriFilterPatternTest.java
@@ -1,0 +1,174 @@
+package DefaultExample;
+
+import io.github.ncasaux.camelplantuml.routebuilder.CamelPlantUmlRouteBuilder;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.mock;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.seda;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.timer;
+
+public class DefaultExampleWithInvalidUriFilterPatternTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Override
+    public boolean useJmx() {
+        return true;
+    }
+
+    @Test
+    public void testMock() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:camel-plantuml-output");
+
+
+        mock.expectedBodiesReceived("@startuml\n" +
+                "\n" +
+                "skinparam ArrowColor #Black\n" +
+                "\n" +
+                "skinparam rectangle {\n" +
+                "  RoundCorner 20\n" +
+                "}\n" +
+                "\n" +
+                "skinparam rectangle<<route>> {\n" +
+                "  BorderColor #6C8EBF\n" +
+                "  BackgroundColor #DAE8FC\n" +
+                "}\n" +
+                "\n" +
+                "skinparam queue<<endpoint>> {\n" +
+                "}\n" +
+                "\n" +
+                "skinparam queue<<static>> {\n" +
+                "  BorderColor #B85450\n" +
+                "  BackgroundColor #F8CECC\n" +
+                "}\n" +
+                "\n" +
+                "skinparam queue<<dynamic>> {\n" +
+                "  BorderColor #82B366\n" +
+                "  BackgroundColor #D5E8D4\n" +
+                "}\n" +
+                "\n" +
+                "footer Generated with camel-plantuml on %date(\"dd-MM-yyyy HH:mm\")\n" +
+                "\n" +
+                "' === Some useful settings for tweaking diagram layout ===\n" +
+                "'left to right direction\n" +
+                "'hide stereotype\n" +
+                "'skinparam nodesep 50\n" +
+                "'skinparam ranksep 50\n" +
+                "'skinparam wrapWidth 250\n" +
+                "\n" +
+                "rectangle route_2ad9f14c90052cf9002f79d5f9fa54cb <<route>> as \"\n" +
+                "mainRoute\n" +
+                "....\n" +
+                "<i>Route which handles processing of the message</i>\n" +
+                "\"\n" +
+                "\n" +
+                "rectangle route_a4212b7daeffab7a6859963fce8df0c1 <<route>> as \"\n" +
+                "fastTimerRoute\n" +
+                "....\n" +
+                "<i>Route which generates fast periodic events</i>\n" +
+                "\"\n" +
+                "\n" +
+                "rectangle route_2c3a25b7f186d9a06118c863dc529551 <<route>> as \"\n" +
+                "transformRoute\n" +
+                "....\n" +
+                "<i>Route which transforms the message</i>\n" +
+                "\"\n" +
+                "\n" +
+                "rectangle route_e75ae82e12c615feefaf77105cf18e63 <<route>> as \"\n" +
+                "slowTimerRoute\n" +
+                "....\n" +
+                "<i>Route which generates slow periodic events</i>\n" +
+                "\"\n" +
+                "\n" +
+                "queue endpoint_9259e64c942ad21bc3beebab69d91941 <<endpoint>><<static>> as \"\n" +
+                "seda://endpoint1\n" +
+                "\"\n" +
+                "\n" +
+                "queue endpoint_c1749b7ed34e5395932c33f971ca4151 <<endpoint>><<static>> as \"\n" +
+                "timer://foo\n" +
+                "\"\n" +
+                "\n" +
+                "queue endpoint_497a674fd655c44f28111e246619dc57 <<endpoint>><<static>> as \"\n" +
+                "timer://bar\n" +
+                "\"\n" +
+                "\n" +
+                "queue endpoint_766e5055e2b624afb926345d34208088 <<endpoint>><<static>> as \"\n" +
+                "direct://endpoint2\n" +
+                "\"\n" +
+                "\n" +
+                "endpoint_497a674fd655c44f28111e246619dc57 --> route_a4212b7daeffab7a6859963fce8df0c1 : from\n" +
+                "\n" +
+                "endpoint_9259e64c942ad21bc3beebab69d91941 --> route_2ad9f14c90052cf9002f79d5f9fa54cb : from\n" +
+                "\n" +
+                "endpoint_c1749b7ed34e5395932c33f971ca4151 --> route_e75ae82e12c615feefaf77105cf18e63 : from\n" +
+                "\n" +
+                "endpoint_766e5055e2b624afb926345d34208088 --> route_2c3a25b7f186d9a06118c863dc529551 : from\n" +
+                "\n" +
+                "route_e75ae82e12c615feefaf77105cf18e63 --> endpoint_9259e64c942ad21bc3beebab69d91941 : to\n" +
+                "\n" +
+                "route_a4212b7daeffab7a6859963fce8df0c1 --> endpoint_9259e64c942ad21bc3beebab69d91941 : to\n" +
+                "\n" +
+                "queue dynamic_producer_endpoint_1846cdc72007895e6140e286368e7049 <<endpoint>><<dynamic>> as \"\n" +
+                "mock://mock-${body}\n" +
+                "\"\n" +
+                "\n" +
+                "route_2ad9f14c90052cf9002f79d5f9fa54cb --> dynamic_producer_endpoint_1846cdc72007895e6140e286368e7049 : toD\n" +
+                "\n" +
+                "route_2ad9f14c90052cf9002f79d5f9fa54cb --> endpoint_766e5055e2b624afb926345d34208088 : enrich\n" +
+                "\n" +
+                "@enduml\n");
+
+        AdviceWith.adviceWith(context, "camel-plantuml-http-trigger", a -> {
+                    a.weaveAddLast().transform(a.body().regexReplaceAll("\r", ""));
+                    a.weaveAddLast().to("mock:camel-plantuml-output");
+                }
+        );
+
+        context.start();
+
+        template.sendBodyAndHeader("direct:camel-plantuml-generate-plantuml", null, "uriFilterPattern","*.foo");
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from(timer("foo").period(5000)).routeId("slowTimerRoute")
+                        .description("Route which generates slow periodic events")
+                        .setBody(constant("slow"))
+                        .to(seda("endpoint1")).id("_to01");
+
+                from(timer("bar").period(1000)).routeId("fastTimerRoute")
+                        .description("Route which generates fast periodic events")
+                        .setBody(constant("fast"))
+                        .to(seda("endpoint1")).id("_to02");
+
+                from(seda("endpoint1")).routeId("mainRoute")
+                        .description("Route which handles processing of the message")
+                        .log(LoggingLevel.INFO, "${body}")
+                        .enrich().constant("direct://endpoint2").id("_enrich01")
+                        .toD(mock("mock-${body}")).id("_toD01");
+
+                from(direct("endpoint2")).routeId("transformRoute")
+                        .description("Route which transforms the message")
+                        .transform(simple("${body}${body}"));
+
+                getContext().addRoutes(new CamelPlantUmlRouteBuilder());
+
+            }
+
+        };
+    }
+}

--- a/camel-plantuml-jar/src/test/java/DefaultExample/DefaultExampleWithUriFilterPatternTest.java
+++ b/camel-plantuml-jar/src/test/java/DefaultExample/DefaultExampleWithUriFilterPatternTest.java
@@ -1,0 +1,160 @@
+package DefaultExample;
+
+import io.github.ncasaux.camelplantuml.routebuilder.CamelPlantUmlRouteBuilder;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.mock;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.seda;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.timer;
+
+public class DefaultExampleWithUriFilterPatternTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Override
+    public boolean useJmx() {
+        return true;
+    }
+
+    @Test
+    public void testMock() throws Exception {
+        MockEndpoint mock = getMockEndpoint("mock:camel-plantuml-output");
+
+
+        mock.expectedBodiesReceived("@startuml\n" +
+                "\n" +
+                "skinparam ArrowColor #Black\n" +
+                "\n" +
+                "skinparam rectangle {\n" +
+                "  RoundCorner 20\n" +
+                "}\n" +
+                "\n" +
+                "skinparam rectangle<<route>> {\n" +
+                "  BorderColor #6C8EBF\n" +
+                "  BackgroundColor #DAE8FC\n" +
+                "}\n" +
+                "\n" +
+                "skinparam queue<<endpoint>> {\n" +
+                "}\n" +
+                "\n" +
+                "skinparam queue<<static>> {\n" +
+                "  BorderColor #B85450\n" +
+                "  BackgroundColor #F8CECC\n" +
+                "}\n" +
+                "\n" +
+                "skinparam queue<<dynamic>> {\n" +
+                "  BorderColor #82B366\n" +
+                "  BackgroundColor #D5E8D4\n" +
+                "}\n" +
+                "\n" +
+                "footer Generated with camel-plantuml on %date(\"dd-MM-yyyy HH:mm\")\n" +
+                "\n" +
+                "' === Some useful settings for tweaking diagram layout ===\n" +
+                "'left to right direction\n" +
+                "'hide stereotype\n" +
+                "'skinparam nodesep 50\n" +
+                "'skinparam ranksep 50\n" +
+                "'skinparam wrapWidth 250\n" +
+                "\n" +
+                "rectangle route_2ad9f14c90052cf9002f79d5f9fa54cb <<route>> as \"\n" +
+                "mainRoute\n" +
+                "....\n" +
+                "<i>Route which handles processing of the message</i>\n" +
+                "\"\n" +
+                "\n" +
+                "rectangle route_a4212b7daeffab7a6859963fce8df0c1 <<route>> as \"\n" +
+                "fastTimerRoute\n" +
+                "....\n" +
+                "<i>Route which generates fast periodic events</i>\n" +
+                "\"\n" +
+                "\n" +
+                "rectangle route_2c3a25b7f186d9a06118c863dc529551 <<route>> as \"\n" +
+                "transformRoute\n" +
+                "....\n" +
+                "<i>Route which transforms the message</i>\n" +
+                "\"\n" +
+                "\n" +
+                "queue endpoint_9259e64c942ad21bc3beebab69d91941 <<endpoint>><<static>> as \"\n" +
+                "seda://endpoint1\n" +
+                "\"\n" +
+                "\n" +
+                "queue endpoint_497a674fd655c44f28111e246619dc57 <<endpoint>><<static>> as \"\n" +
+                "timer://bar\n" +
+                "\"\n" +
+                "\n" +
+                "queue endpoint_766e5055e2b624afb926345d34208088 <<endpoint>><<static>> as \"\n" +
+                "direct://endpoint2\n" +
+                "\"\n" +
+                "\n" +
+                "endpoint_497a674fd655c44f28111e246619dc57 --> route_a4212b7daeffab7a6859963fce8df0c1 : from\n" +
+                "\n" +
+                "endpoint_9259e64c942ad21bc3beebab69d91941 --> route_2ad9f14c90052cf9002f79d5f9fa54cb : from\n" +
+                "\n" +
+                "endpoint_766e5055e2b624afb926345d34208088 --> route_2c3a25b7f186d9a06118c863dc529551 : from\n" +
+                "\n" +
+                "route_a4212b7daeffab7a6859963fce8df0c1 --> endpoint_9259e64c942ad21bc3beebab69d91941 : to\n" +
+                "\n" +
+                "queue dynamic_producer_endpoint_1846cdc72007895e6140e286368e7049 <<endpoint>><<dynamic>> as \"\n" +
+                "mock://mock-${body}\n" +
+                "\"\n" +
+                "\n" +
+                "route_2ad9f14c90052cf9002f79d5f9fa54cb --> dynamic_producer_endpoint_1846cdc72007895e6140e286368e7049 : toD\n" +
+                "\n" +
+                "route_2ad9f14c90052cf9002f79d5f9fa54cb --> endpoint_766e5055e2b624afb926345d34208088 : enrich\n" +
+                "\n" +
+                "@enduml\n");
+
+        AdviceWith.adviceWith(context, "camel-plantuml-http-trigger", a -> {
+                    a.weaveAddLast().transform(a.body().regexReplaceAll("\r", ""));
+                    a.weaveAddLast().to("mock:camel-plantuml-output");
+                }
+        );
+
+        context.start();
+
+        template.sendBodyAndHeader("direct:camel-plantuml-generate-plantuml", null, "uriFilterPattern",".*foo.*");
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from(timer("foo").period(5000)).routeId("slowTimerRoute")
+                        .description("Route which generates slow periodic events")
+                        .setBody(constant("slow"))
+                        .to(seda("endpoint1")).id("_to01");
+
+                from(timer("bar").period(1000)).routeId("fastTimerRoute")
+                        .description("Route which generates fast periodic events")
+                        .setBody(constant("fast"))
+                        .to(seda("endpoint1")).id("_to02");
+
+                from(seda("endpoint1")).routeId("mainRoute")
+                        .description("Route which handles processing of the message")
+                        .log(LoggingLevel.INFO, "${body}")
+                        .enrich().constant("direct://endpoint2").id("_enrich01")
+                        .toD(mock("mock-${body}")).id("_toD01");
+
+                from(direct("endpoint2")).routeId("transformRoute")
+                        .description("Route which transforms the message")
+                        .transform(simple("${body}${body}"));
+
+                getContext().addRoutes(new CamelPlantUmlRouteBuilder());
+
+            }
+
+        };
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>io.github.ncasaux</groupId>
   <artifactId>camel-plantuml</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.0</version>
+  <version>1.8.0-SNAPSHOT</version>
   <modules>
     <module>camel-plantuml-jar</module>
     <module>camel-plantuml-zip</module>


### PR DESCRIPTION
Camel-plantuml is a powerful tool for visualizing Camel routes, from small and simple routes to larger and more complex ones. In my use cases with complex routes, however, I found that certain endpoints were irrelevant to the specific diagrams I wanted to create, and their inclusion sometimes reduced clarity.

This PR introduces a new URL parameter (`uriFilterPattern`), allowing users to filter out specified endpoints in the PlantUML output, thereby better aligning the visual output to specific needs and enhancing readability for focused use cases. I’ve included two unit tests to demonstrate the parameter’s use.